### PR TITLE
【feature/DBmigration】usertype_id move to profiles to fix registration

### DIFF
--- a/database/migrations/2023_11_04_013803_drop_column_users_column.php
+++ b/database/migrations/2023_11_04_013803_drop_column_users_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('usertype_id');  //Column削除
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedBigInteger('usertype_id'); // Column追加
+        });
+    }
+};

--- a/database/migrations/2023_11_04_013815_add_usertype_id_to_profiles.php
+++ b/database/migrations/2023_11_04_013815_add_usertype_id_to_profiles.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('profiles', function (Blueprint $table) {
+            $table->unsignedBigInteger('usertype_id'); // Column追加
+
+            $table->foreign('usertype_id')
+                ->references('id')
+                ->on('usertypes');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('profiles', function (Blueprint $table) {
+            $table->dropColumn('usertype_id');  //Column削除
+        });
+    }
+};


### PR DESCRIPTION
Move usertype_id column from users to profiles.
Because usertype_id column has foreign-key restriction so we can't save record by null exception when regist users.
